### PR TITLE
Improve content synchronization

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,15 @@ docker run -it -v ~/hugo-site:/site markdown-to-confluence:v1.0 --api_url "CONFL
 # Usage
 
 ```
-usage: markdown-to-confluence.py [-h] [--api_url API_URL] [--space SPACE] [--username USERNAME] [--password PASSWORD]
-      
-      [--dir DIR] [--git GIT] [--global_label GLOBAL_LABEL] [--header HEADER]
-      [--dry-run] [--force] [--save-cookie SAVE_COOKIE] [--cookie-file COOKIE]
-      [posts ...]
+usage: markdown-to-confluence.py [-h] [--api_url API_URL] [--space SPACE]
+                                 [--username USERNAME] [--password PASSWORD]
+                                 [--dir DIR] [--git GIT]
+                                 [--global_label GLOBAL_LABEL]
+                                 [--header HEADER] [--dry-run] [--force]
+                                 [--no-minoredit] [--no-optimizeattachments]
+                                 [--save-cookie SAVE_COOKIE]
+                                 [--cookie-file COOKIE]
+                                 [posts [posts ...]]
 
 Converts and deploys a single or directory of markdown page/s to Confluence
 
@@ -57,10 +61,12 @@ optional arguments:
   --header HEADER       Extra header to include in the request when sending HTTP to a server. May be specified multiple times. (default: env('CONFLUENCE_HEADER_<NAME>'))
   --dry-run             Print requests that would be sent - don't actually make requests against Confluence (note: we return empty responses, so this might impact accuracy)
   --force               Can be used with --git flag. Upload pages without checking for changes
+  --no-minoredit        Don't use minorEdit flag when creating content and trigger notifications for all changes
+  --no-optimizeattachments
+                        Upload all attachments everytime
   --save-cookie SAVE_COOKIE
                         File system location to write cookie
   --cookie-file COOKIE  Instead of using a user name and password use a cookie created with --save-cookie
-
 ```
 
 ## What Posts are Deployed?

--- a/markdown-to-confluence.py
+++ b/markdown-to-confluence.py
@@ -148,6 +148,12 @@ def parse_args():
         help='Can be used with --git flag. Upload pages without checking for changes'
     )
     parser.add_argument(
+        '--no-minoredit',
+        dest='minoredit',
+        action='store_false',
+        help='Don\'t use minorEdit flag when creating content and trigger notifications for all changes'
+    )
+    parser.add_argument(
         '--save-cookie',
         dest='save_cookie',
         default=None,
@@ -312,7 +318,8 @@ def main():
                             password=args.password,
                             cookie=args.cookie,
                             headers=args.headers,
-                            dry_run=args.dry_run)
+                            dry_run=args.dry_run,
+                            minoredit=args.minoredit)
 
     if args.save_cookie:
         log.info('Attempting to save cookie.  Input files will be ignored')

--- a/markdown-to-confluence.py
+++ b/markdown-to-confluence.py
@@ -154,6 +154,12 @@ def parse_args():
         help='Don\'t use minorEdit flag when creating content and trigger notifications for all changes'
     )
     parser.add_argument(
+        '--no-optimizeattachments',
+        dest='optimizeattachments',
+        action='store_false',
+        help='Upload all attachments everytime'
+    )
+    parser.add_argument(
         '--save-cookie',
         dest='save_cookie',
         default=None,
@@ -319,6 +325,7 @@ def main():
                             cookie=args.cookie,
                             headers=args.headers,
                             dry_run=args.dry_run,
+                            optimizeattachments=args.optimizeattachments,
                             minoredit=args.minoredit)
 
     if args.save_cookie:

--- a/markdown_to_confluence/confluence.py
+++ b/markdown_to_confluence/confluence.py
@@ -32,6 +32,7 @@ class Confluence():
                  cookie=None,
                  headers=None,
                  dry_run=False,
+                 minoredit=True,
                  _client=None):
         """Creates a new Confluence API client.
         
@@ -41,6 +42,7 @@ class Confluence():
             password {str} -- The Confluence service account password
             headers {list(str)} -- The HTTP headers which will be set for all requests
             dry_run {str} -- The Confluence service account password
+            minoredit {bool} -- Flag for minorEdit in Confluence
         """
         # A common gotcha will be given a URL that doesn't end with a /, so we
         # can account for this
@@ -51,6 +53,7 @@ class Confluence():
         self.username = username
         self.password = password
         self.dry_run = dry_run
+        self.minoredit = minoredit
 
         if _client is None:
             _client = requests.Session()
@@ -299,7 +302,7 @@ class Confluence():
         if not self.dry_run:
             self.post(path=path,
                     params={'allowDuplicated': 'true'},
-                    files={'file': open(attachment_path, 'rb')})
+                    files={'minorEdit': self.minoredit, 'file': open(attachment_path, 'rb')})
         log.info('Uploaded {} to post ID {}'.format(attachment_path, post_id))
 
     def get_author(self, username):
@@ -424,7 +427,7 @@ class Confluence():
         # Increment the version number, as required by the Confluence API
         # https://docs.atlassian.com/ConfluenceServer/rest/7.1.0/#api/content-update
         new_version = page['version']['number'] + 1
-        new_page['version'] = {'number': new_version}
+        new_page['version'] = {'minorEdit': self.minoredit, 'number': new_version}
 
         # With the attachments uploaded, and our new page structure created,
         # we can upload the final content up to Confluence.


### PR DESCRIPTION
These changes reduces mailspam when updating pages and attachments in Confluence.

Without the `minorEdit` parameter every change creates a mail for all watchers. The default is now changed to use `minorEdit=True` and thus not create notification mails. The previous behaviour can be restored by using the new cli option `--no-minoredit`.

Another implemented optimization is focused on attachments. The previous implementation was syncing all attachments everytime. When a page has a lot of attachments, this quickly creates many versions and wastes storage. The optimization uses the comment field to store a hash of the uploaded file and only re-uploads the contetns, if the hash of the current file does not match the one stored in comment. This behaviour can also be disabled by specifying `--no-optimizeattachments` .